### PR TITLE
Use raw github URL as parameter to kubectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ authenticator on your Kubernetes master using host networking so that the
 apiserver can access the authenticator through the loopback interface.
 
 ```
-kubectl create -f https://github.com/oursky/kubernetes-github-authn/blob/master/manifests/github-authn.yaml
+kubectl create -f https://raw.github.com/oursky/kubernetes-github-authn/blob/master/manifests/github-authn.yaml
 ```
 
 Confirm that the authenticator is running:
 
 ```
-kubectl get pod -l k8s-app=github-authn
+kubectl get ds -l k8s-app=github-authn -n kube-system
 ```
 
 Next, configure apiserver to verify bearer token using this authenticator.
@@ -60,7 +60,7 @@ access to the project `project1`. First of all, we need to define a new role
 called `admin` which can control all resources.
 
 ```
-kubectl create -f https://github.com/oursky/kubernetes-github-authn/blob/master/manifests/admin-cluster-role.yaml
+kubectl create -f https://raw.github.com/oursky/kubernetes-github-authn/blob/master/manifests/admin-cluster-role.yaml
 ```
 
 We need to assign `johndoe` to this `admin` role so that he has control to


### PR DESCRIPTION
kubectl needs the raw version of the yaml document, without adding "raw." on
the github URL the version that would be served is going to be HTML.