### PR TITLE
Add name to the container in the DaemonSet

### DIFF
--- a/manifests/github-authn.yaml
+++ b/manifests/github-authn.yaml
@@ -18,6 +18,7 @@ spec:
     spec:
       containers:
       - image: oursky/kubernetes-github-authn
+        name: kubernetes-github-authn
         ports:
         - containerPort: 3000
           hostPort: 3000


### PR DESCRIPTION
Before this change the kubectl validation was failing, a name is required in
the list of containers to be executed as part of the DaemonSet.