### PR TITLE
Team update

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,26 @@ a `RoleBinding`:
 kubectl create clusterrolebinding johndoe-admin-binding --clusterrole=admin --user=johndoe
 ```
 
+### Groups
+RBAC supports assigning permissions to users via a group. The authenticator will 
+map all Github Organization Teams to groups in Kubernetes. See the [team example
+](/manifests/operations-cluster-role.yaml) for an example of how assign these
+permissions.
+
+If you plan to use Groups, make sure you set the `GITHUB_ORG` environment variable
+on your [DaemonSet manifest](manifests/github-authn.yaml) before applying it. Simply
+uncomment the `name` and `value` for `GITHUB_ORG` and set the `value` to your Github
+Organization name. For example, Oursky's github Organization URL is https://github.com/oursky,
+and we would set the manifest to read:
+
+```
+...
+        env:
+        - name: GITHUB_ORG
+          value: oursky
+...
+```
+
 Read the [Kubernetes
 documentation](https://kubernetes.io/docs/admin/authorization/rbac/) to learn
 more about how to configure your apiserver to use RBAC.

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
@@ -65,8 +66,14 @@ func main() {
 			})
 			return
 		}
+		os.Getenv("GITHUB_ORG")
 		var groups []string
 		for _, team := range teams_results {
+			if org != "" {
+				if !(strings.EqualFold(org, *team.Organization.Login)) {
+					continue
+				}
+			}
 			groups = append(teams, *team.Name)
 		}
 

--- a/main.go
+++ b/main.go
@@ -76,6 +76,11 @@ func main() {
 				}
 			}
 			groups = append(groups, *team.Name)
+
+			// Handle child teams
+			if team.Parent != nil {
+				teams = append(teams, *team.Parent.Name)
+			}
 		}
 
 		log.Printf("[Success] login as %s", *user.Login)

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func main() {
 
 			// Handle child teams
 			if team.Parent != nil {
-				teams = append(teams, *team.Parent.Name)
+				groups = append(groups, *team.Parent.Name)
 			}
 		}
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
@@ -66,7 +67,7 @@ func main() {
 			})
 			return
 		}
-		os.Getenv("GITHUB_ORG")
+		org := os.Getenv("GITHUB_ORG")
 		var groups []string
 		for _, team := range teams_results {
 			if org != "" {
@@ -74,7 +75,7 @@ func main() {
 					continue
 				}
 			}
-			groups = append(teams, *team.Name)
+			groups = append(groups, *team.Name)
 		}
 
 		log.Printf("[Success] login as %s", *user.Login)

--- a/manifests/github-authn.yaml
+++ b/manifests/github-authn.yaml
@@ -23,6 +23,9 @@ spec:
         - containerPort: 3000
           hostPort: 3000
           protocol: TCP
+        env:
+#        - name: GITHUB_ORG
+#          value: <github org name>
       hostNetwork: true
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/manifests/operations-cluster-role.yaml
+++ b/manifests/operations-cluster-role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: operations 
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  # This name maps to a Github Organization Team named Operations
+  name: Operations


### PR DESCRIPTION
This update adds support for mapping Github Organization Teams to Groups in Kubernetes. Simply set `GITHUB_ORG` environment variable on the DaemonSet, and any teams the authenticated user belongs to within the matching Organization will be assigned as Groups in Kubernetes. RBAC permissions can then be applied at the group level. 